### PR TITLE
RepoCompose: fix get_variant_url()

### DIFF
--- a/bucko/repo_compose.py
+++ b/bucko/repo_compose.py
@@ -27,8 +27,7 @@ class RepoCompose(productmd.compose.Compose):
         self.keys.update(keys)
 
     def get_variant_url(self, v, arch):
-        return posixpath.join(self.compose_path, 'compose',
-                              v.paths.repository[arch])
+        return posixpath.join(self.compose_path, v.paths.repository[arch])
 
     def get_variant_gpg_key(self, v, arch):
         """

--- a/bucko/tests/test_repo_compose.py
+++ b/bucko/tests/test_repo_compose.py
@@ -28,6 +28,16 @@ class TestRepoComposeTrivial(object):
         assert repocompose.info.get_variants()
 
 
+class TestRepoComposeVariantUrl(object):
+
+    def test_get_variant_url(self, repocompose):
+        variants = repocompose.info.get_variants()
+        assert len(variants) > 0
+        result = repocompose.get_variant_url(variants[0], 'x86_64')
+        expected = os.path.join(FIXTURES_DIR, 'MON', 'x86_64', 'os')
+        assert result == expected
+
+
 class TestRepoComposeYumRepo(object):
     """ Test attributes """
 


### PR DESCRIPTION
Remove the stray "compose" from this URL. This was causing the docker build
process to use the wrong repository URLs (yum would fail with HTTP 404 errors).